### PR TITLE
Default ingress.annotations to an empty map

### DIFF
--- a/charts/yourls/values.yaml
+++ b/charts/yourls/values.yaml
@@ -159,7 +159,7 @@ ingress:
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
+  annotations: {}
   #  kubernetes.io/ingress.class: nginx
 
   ## The list of hostnames to be covered with this ingress record.


### PR DESCRIPTION
## what

Default ingress.annotations to an empty map

## why

I often see this warning when performing a diff with helmfile, which I believe is caused by the fields type being misinterpreted

```
Comparing yourls yourls/yourls
2019/04/24 23:36:02 warning: destination for annotations is a table. Ignoring non-table value <nil>
```